### PR TITLE
Add testing/CI through GitHub actions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,40 @@
+name: Linux
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        version:
+          - "1"
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - name: Cache artifacts
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-uploadcodecov@latest
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
         env:
-          API_KEY: ${{ secrets.API_KEY }}
+          CMAP_API_KEY: ${{ secrets.CMAP_API_KEY }}
       - uses: julia-actions/julia-uploadcodecov@latest
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -35,6 +35,8 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
+        env:
+          API_KEY: ${{ secrets.API_KEY }}
       - uses: julia-actions/julia-uploadcodecov@latest
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/linux_nightly.yml
+++ b/.github/workflows/linux_nightly.yml
@@ -1,0 +1,40 @@
+name: Linux nightly
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        version:
+          - "nightly"
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - name: Cache artifacts
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-uploadcodecov@latest
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/linux_nightly.yml
+++ b/.github/workflows/linux_nightly.yml
@@ -35,6 +35,8 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
+        env:
+          CMAP_API_KEY: ${{ secrets.CMAP_API_KEY }}
       - uses: julia-actions/julia-uploadcodecov@latest
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,0 +1,40 @@
+name: Mac OS X
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        version:
+          - "1"
+        os:
+          - macOS-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - name: Cache artifacts
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-uploadcodecov@latest
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -35,7 +35,8 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
+        env:
+          CMAP_API_KEY: ${{ secrets.CMAP_API_KEY }}
       - uses: julia-actions/julia-uploadcodecov@latest
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-          CMAP_API_KEY: ${{ secrets.CMAP_API_KEY }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -38,4 +38,4 @@ jobs:
       - uses: julia-actions/julia-uploadcodecov@latest
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-          API_KEY: ${{ secrets.API_KEY }}
+          CMAP_API_KEY: ${{ secrets.CMAP_API_KEY }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -38,3 +38,4 @@ jobs:
       - uses: julia-actions/julia-uploadcodecov@latest
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          API_KEY: ${{ secrets.API_KEY }}

--- a/.github/workflows/mac_nightly.yml
+++ b/.github/workflows/mac_nightly.yml
@@ -1,0 +1,40 @@
+name: Mac OS X nightly
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        version:
+          - "nightly"
+        os:
+          - macOS-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - name: Cache artifacts
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-uploadcodecov@latest
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/mac_nightly.yml
+++ b/.github/workflows/mac_nightly.yml
@@ -35,6 +35,8 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
+        env:
+          CMAP_API_KEY: ${{ secrets.CMAP_API_KEY }}
       - uses: julia-actions/julia-uploadcodecov@latest
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,40 @@
+name: Windows
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        version:
+          - "1"
+        os:
+          - windows-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - name: Cache artifacts
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-uploadcodecov@latest
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,6 +35,8 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
+        env:
+          CMAP_API_KEY: ${{ secrets.CMAP_API_KEY }}
       - uses: julia-actions/julia-uploadcodecov@latest
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/windows_nightly.yml
+++ b/.github/workflows/windows_nightly.yml
@@ -1,0 +1,40 @@
+name: Windows nightly
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        version:
+          - "nightly"
+        os:
+          - windows-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - name: Cache artifacts
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-uploadcodecov@latest
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/windows_nightly.yml
+++ b/.github/workflows/windows_nightly.yml
@@ -35,6 +35,8 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
+        env:
+          CMAP_API_KEY: ${{ secrets.CMAP_API_KEY }}
       - uses: julia-actions/julia-uploadcodecov@latest
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,25 @@
 ![Cover](pic/CMAP.png)
 
+<p>
+  <a href="https://github.com/simonscmap/CMAP.jl/actions">
+    <img src="https://img.shields.io/github/workflow/status/simonscmap/CMAP.jl/Mac%20OS%20X?label=OSX&logo=Apple&logoColor=white&style=flat-square">
+  </a>
+  <a href="https://github.com/simonscmap/CMAP.jl/actions">
+    <img src="https://img.shields.io/github/workflow/status/simonscmap/CMAP.jl/Linux?label=Linux&logo=Linux&logoColor=white&style=flat-square">
+  </a>
+  <a href="https://github.com/simonscmap/CMAP.jl/actions">
+    <img src="https://img.shields.io/github/workflow/status/simonscmap/CMAP.jl/Windows?label=Windows&logo=Windows&logoColor=white&style=flat-square">
+  </a>
+  <a href="https://codecov.io/gh/simonscmap/CMAP.jl">
+    <img src="https://img.shields.io/codecov/c/github/simonscmap/CMAP.jl/master?label=Codecov&logo=codecov&logoColor=white&style=flat-square">
+  </a>
+</p>
+
 # cmap.jl
 
 CMAP.jl is the Julia client for Simons CMAP project. It provides access to the Simons CMAP database where various ocean data sets are hosted. These data sets include multi decades of remote sensing observations (satellite), numerical model estimates, and field expeditions.
 
-This package is adopted from [pycmap](https://github.com/simonscmap/pycmap), which is the python client of Simons CMAP ecosystem. 
+This package is adopted from [pycmap](https://github.com/simonscmap/pycmap), which is the python client of Simons CMAP ecosystem.
 
 ## Documentation
 
@@ -13,7 +28,7 @@ To be filled out.
 ## Usage example
 
 1. Set your Simons API key.
-    
+
     To make API requests, you need to get an API key from [Simons CMAP website](https://simonscmap.com). Once you have your API key, run the following command to store the API key on your local machine:
 
     ```julia
@@ -27,20 +42,20 @@ To be filled out.
     datasets()
     ```
 
-1. Retrieve a subset of sea surface temperature measured by satellite. 
- 
+1. Retrieve a subset of sea surface temperature measured by satellite.
+
     ```julia
     space_time(
-               table = "tblArgoMerge_REP", 
-               variable = "argo_merge_salinity_adj", 
-               dt1 = "2015-05-01", 
-               dt2 = "2015-05-30", 
-               lat1 = 28.1, 
-               lat2 = 35.4, 
-               lon1 = -71.3, 
-               lon2 = -50, 
-               depth1 = 0, 
+               table = "tblArgoMerge_REP",
+               variable = "argo_merge_salinity_adj",
+               dt1 = "2015-05-01",
+               dt2 = "2015-05-30",
+               lat1 = 28.1,
+               lat2 = 35.4,
+               lon1 = -71.3,
+               lon2 = -50,
+               depth1 = 0,
                depth2 = 100
-           )
+              )
     ```
 

--- a/src/rest.jl
+++ b/src/rest.jl
@@ -74,7 +74,7 @@ function get_api_key()
     keyFile = api_key_fname()
     if isfile(keyFile)
         return DataFrame(CSV.File(keyFile))[1, 1]
-    else if haskey(ENV, "CMAP_API_KEY")
+    elseif haskey(ENV, "CMAP_API_KEY")
         return ENV["CMAP_API_KEY"]
     else
         error("""

--- a/src/rest.jl
+++ b/src/rest.jl
@@ -72,10 +72,17 @@ get_api_key()
 """
 function get_api_key()
     keyFile = api_key_fname()
-    if ~isfile(keyFile)
-        error("API Key file not found. The following command will register the API key:\n\nset_api_key(key::String)\n\n")
-    end    
-    return DataFrame(CSV.File(keyFile))[1, 1]
+    if !isfile(keyFile)
+        error("""
+              API Key file not found. The following command will register the API key:
+
+              ```
+              set_api_key("Your API Key here")
+              ```
+              """)
+    else # Allow for environment variable secret API key for testing?
+        return get(ENV, "CMAP_API_KEY", DataFrame(CSV.File(keyFile))[1, 1])
+    end
 end
 
 

--- a/src/rest.jl
+++ b/src/rest.jl
@@ -72,7 +72,11 @@ get_api_key()
 """
 function get_api_key()
     keyFile = api_key_fname()
-    if !isfile(keyFile)
+    if isfile(keyFile)
+        return DataFrame(CSV.File(keyFile))[1, 1]
+    else if haskey(ENV, "CMAP_API_KEY")
+        return ENV["CMAP_API_KEY"]
+    else
         error("""
               API Key file not found. The following command will register the API key:
 
@@ -80,8 +84,6 @@ function get_api_key()
               set_api_key("Your API Key here")
               ```
               """)
-    else # Allow for environment variable secret API key for testing?
-        return get(ENV, "CMAP_API_KEY", DataFrame(CSV.File(keyFile))[1, 1])
     end
 end
 


### PR DESCRIPTION
This PR adds CI/tests for CMAP.jl through GitHub actions. I'm not entirely sure this is how to do this, but it worked on my fork, so I thought I should make a PR out of it.

For this to work, you will need to add an API key as a "secret" that should be called `CMAP_API_KEY` on the repository.
During testing, this key is inserted in the `ENV` variable, which the new `get_api_key()` function checks if the API key is not in the key file (no key file online).

I also added some badges like these below to the ReadMe to get a direct indication if something did not pass the tests:

<p>
  <a href="https://github.com/briochemc/CMAP.jl/actions">
    <img src="https://img.shields.io/github/workflow/status/briochemc/CMAP.jl/Mac%20OS%20X?label=OSX&logo=Apple&logoColor=white&style=flat-square">
  </a>
  <a href="https://github.com/briochemc/CMAP.jl/actions">
    <img src="https://img.shields.io/github/workflow/status/briochemc/CMAP.jl/Linux?label=Linux&logo=Linux&logoColor=white&style=flat-square">
  </a>
  <a href="https://github.com/briochemc/CMAP.jl/actions">
    <img src="https://img.shields.io/github/workflow/status/briochemc/CMAP.jl/Windows?label=Windows&logo=Windows&logoColor=white&style=flat-square">
  </a>
</p>


FYI, these badges point to my fork (where I added my API Key as the `CMAP_API_KEY` secret), but this PR's added badges point to simonscmap/CMAP.jl, so they might appear red/failing until you add your own `CMAP_API_KEY` secret on simonscmap/CMAP.jl.
